### PR TITLE
test(yaml): Added new tests for templates

### DIFF
--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -189,6 +189,33 @@ describe('util/yaml', () => {
         },
       ]);
     });
+
+    it('should parse content with templates using colons in keys/values', () => {
+      expect(
+        parseYaml(
+          codeBlock`
+            myObject:
+              aString: {{ value }}
+              {{ prefixKey }}anotherString: "value"
+            ---
+            foo: {{ foo.bar }}
+            bar: "value{{ value }}:v2"
+          `,
+          { removeTemplates: true },
+        ),
+      ).toEqual([
+        {
+          myObject: {
+            aString: null,
+            anotherString: "value"
+          },
+        },
+        {
+          foo: null,
+          bar: "value:v2"
+        },
+      ]);
+    });
   });
 
   describe('load', () => {
@@ -291,6 +318,33 @@ describe('util/yaml', () => {
           aString: null,
           myNestedObject: {
             aNestedString: null,
+          },
+        },
+      });
+    });
+
+    it('should parse content with template using colons in keys/values', () => {
+      expect(
+        parseSingleYaml(
+          codeBlock`
+            myObject:
+              aString: {{value}}
+              {{prefixKey}}anotherString: "value"
+              {% if test.enabled %}
+              myNestedObject:
+                aNestedString: {{value}}
+                anotherNestedString: "value{{value}}:v2"
+              {% endif %}
+          `,
+          { removeTemplates: true },
+        ),
+      ).toEqual({
+        myObject: {
+          aString: null,
+          anotherString: "value",
+          myNestedObject: {
+            aNestedString: null,
+            anotherNestedString: "value:v2"
           },
         },
       });

--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -190,16 +190,16 @@ describe('util/yaml', () => {
       ]);
     });
 
-    it('should parse content with templates using colons in keys/values', () => {
+    it('should parse content with templates without quotes', () => {
       expect(
         parseYaml(
           codeBlock`
             myObject:
               aString: {{ value }}
-              {{ prefixKey }}anotherString: "value"
+              {{ prefixKey }}anotherString: value
             ---
             foo: {{ foo.bar }}
-            bar: "value{{ value }}:v2"
+            bar: value{{ value }}:v2
           `,
           { removeTemplates: true },
         ),
@@ -323,17 +323,17 @@ describe('util/yaml', () => {
       });
     });
 
-    it('should parse content with template using colons in keys/values', () => {
+    it('should parse content with template without quotes', () => {
       expect(
         parseSingleYaml(
           codeBlock`
             myObject:
               aString: {{value}}
-              {{prefixKey}}anotherString: "value"
+              {{prefixKey}}anotherString: value
               {% if test.enabled %}
               myNestedObject:
                 aNestedString: {{value}}
-                anotherNestedString: "value{{value}}:v2"
+                anotherNestedString: value{{value}}:v2
               {% endif %}
           `,
           { removeTemplates: true },


### PR DESCRIPTION
## Changes

- Added new tests that should fail at the moment, since the YAML Parser is not fixed, at first
- Removing the regex pattern will allow parsing this example file, without replacing almost the whole file, in the following situations:

```yaml
networks: 
  {{ custom_network }}: 
    external: true

services:
  service_xpto: 
    hostname: {{ custom_value }}
    image: "{{ image }}:{{ version }}"
    deploy:
      labels: 
        label: {{ custom_value }}
        {{ prefix }}image:{{ custom_value }}
        ...
```

## Context

The workaround is to use double quotes, which does not make sense since Jinja does not need quotes to parse a template correctly.

Added new tests to cover the observed issue.

Without the regex pattern, the `docker-compose` manager works, and all images are correctly discovered and updated without any issues.

 - https://github.com/renovatebot/renovate/discussions/32967

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
